### PR TITLE
Add support for turning heater off

### DIFF
--- a/src/Adafruit_SGP40.cpp
+++ b/src/Adafruit_SGP40.cpp
@@ -88,6 +88,19 @@ boolean Adafruit_SGP40::softReset(void) {
 }
 
 /**
+ * @brief Request the sensor to turn off heater to lower curent consumption.
+ *        Launching a measurement automatically wakes up the sensor again.
+ *
+ * @return true: success false: failure
+ */
+bool Adafruit_SGP40::heaterOff(void) {
+  uint8_t command[2];
+  command[0] = 0x36;
+  command[1] = 0x15;
+  return i2c_dev->write(command, 2);
+}
+
+/**
  * @brief Request the sensor to perform a self-test, returning the result
  *
  * @return true: success false:failure

--- a/src/Adafruit_SGP40.h
+++ b/src/Adafruit_SGP40.h
@@ -49,6 +49,7 @@ public:
   bool selfTest(void);
 
   bool softReset();
+  bool heaterOff();
   uint16_t measureRaw(float temperature = 25, float humidity = 50);
   int32_t measureVocIndex(float temperature = 25, float humidity = 50);
 


### PR DESCRIPTION
This pull request enables the SGP40 to enter lower power mode by shutting off the heater, using the sgp4x_turn_heater_off command found in the datasheet. 

The added code should have no impact to existing users of the library, and calling measureVocIndex() or measureRaw() will have the sensor automatically re-enable the heater and operate as usual, no additional wake up function is needed.

The successful lowering of power consumption is verified with a nrf PPK2, with a ~2 mA drop in current consumption after turning off the heater, which matches the datasheet current consumption characteristics.
