### PR TITLE
add functions for VocAlgorithm state management

### DIFF
--- a/src/Adafruit_SGP40.cpp
+++ b/src/Adafruit_SGP40.cpp
@@ -69,7 +69,6 @@ boolean Adafruit_SGP40::begin(TwoWire *theWire) {
 
   VocAlgorithm_init(&voc_algorithm_params);
 
-
   return selfTest();
 }
 
@@ -173,8 +172,7 @@ uint16_t Adafruit_SGP40::measureRaw(float temperature, float humidity) {
  * @param state0 first state value
  * @param state1 second state value
  */
-void Adafruit_SGP40::getStates(int32_t* state0, int32_t* state1)
-{
+void Adafruit_SGP40::getStates(int32_t *state0, int32_t *state1) {
   VocAlgorithm_get_states(&voc_algorithm_params, state0, state1);
 }
 
@@ -184,8 +182,7 @@ void Adafruit_SGP40::getStates(int32_t* state0, int32_t* state1)
  * @param state0 first state value
  * @param state1 second state value
  */
-void Adafruit_SGP40::setStates(int32_t state0, int32_t state1)
-{
+void Adafruit_SGP40::setStates(int32_t state0, int32_t state1) {
   VocAlgorithm_set_states(&voc_algorithm_params, state0, state1);
 }
 

--- a/src/Adafruit_SGP40.h
+++ b/src/Adafruit_SGP40.h
@@ -33,10 +33,10 @@ extern "C" {
 #define SGP40_I2CADDR_DEFAULT 0x59 ///< SGP40 has only one I2C address
 
 // commands and constants
-#define SGP40_FEATURESET 0x0020    ///< The required set for this library
+#define SGP40_FEATURESET 0x0020 ///< The required set for this library
 #define SGP40_CRC8_POLYNOMIAL 0x31 ///< Seed for SGP40's CRC polynomial
-#define SGP40_CRC8_INIT 0xFF       ///< Init value for CRC
-#define SGP40_WORD_LEN 2           ///< 2 bytes per word
+#define SGP40_CRC8_INIT 0xFF ///< Init value for CRC
+#define SGP40_WORD_LEN 2 ///< 2 bytes per word
 
 /*!
  *  @brief  Class that stores state and functions for interacting with
@@ -53,10 +53,10 @@ public:
   uint16_t measureRaw(float temperature = 25, float humidity = 50);
   int32_t measureVocIndex(float temperature = 25, float humidity = 50);
 
- /*
- * functions for storing and restoring VocAlgorithm state
- */
-  void getStates(int32_t* state0, int32_t* state1);
+  /*
+   * functions for storing and restoring VocAlgorithm state
+   */
+  void getStates(int32_t *state0, int32_t *state1);
   void setStates(int32_t state0, int32_t state1);
 
   /** The 48-bit serial number, this value is set when you call {@link begin()}


### PR DESCRIPTION
To avoid that the VocAlgorithm instance needs to calibrate its baseline from the scratch after power interruption it is useful to be able to maintain the VocAlgorithm internal state (e.g. on flash rom).
So it can be restored when the sensor is powered on again and therefor is able to immediately continue operation with meaningful values in a "know" environment.

(The VocAlgorithm-implementation already offers management functions for that)