### PR TITLE
Runtime improvements

### DIFF
--- a/src/Adafruit_SGP40.cpp
+++ b/src/Adafruit_SGP40.cpp
@@ -145,9 +145,10 @@ int32_t Adafruit_SGP40::measureVocIndex(float temperature, float humidity) {
  * @param humidity The measured relative humidity in % rH
  * @return int32_t The VOC Index
  */
-int32_t Adafruit_SGP40::calculateVocIndex(uint16_t sraw, float temperature, float humidity) {
+int32_t Adafruit_SGP40::calculateVocIndex(uint16_t sraw, float temperature,
+                                          float humidity) {
   int32_t voc_index;
-  
+
   VocAlgorithm_process(&voc_algorithm_params, sraw, &voc_index);
   return voc_index;
 }
@@ -181,8 +182,6 @@ uint16_t Adafruit_SGP40::measureRaw(float temperature, float humidity) {
 
   return reply;
 }
-
-
 
 /*!
  *  @brief  I2C low level interfacing

--- a/src/Adafruit_SGP40.cpp
+++ b/src/Adafruit_SGP40.cpp
@@ -137,6 +137,22 @@ int32_t Adafruit_SGP40::measureVocIndex(float temperature, float humidity) {
 }
 
 /**
+ * @brief Combined the measured gasses, temperature, and humidity
+ * to calculate the VOC Index
+ *
+ * @param sraw The measured raw value
+ * @param temperature The measured temperature in degrees C
+ * @param humidity The measured relative humidity in % rH
+ * @return int32_t The VOC Index
+ */
+int32_t Adafruit_SGP40::calculateVocIndex(uint16_t sraw, float temperature, float humidity) {
+  int32_t voc_index;
+  
+  VocAlgorithm_process(&voc_algorithm_params, sraw, &voc_index);
+  return voc_index;
+}
+
+/**
  * @brief Return the raw gas measurement
  *
  * @param temperature The measured temperature in degrees C
@@ -160,11 +176,13 @@ uint16_t Adafruit_SGP40::measureRaw(float temperature, float humidity) {
   command[7] = generateCRC(command + 5, 2);
   ;
 
-  if (!readWordFromCommand(command, 8, 250, &reply, 1))
+  if (!readWordFromCommand(command, 8, 100, &reply, 1))
     return 0x0;
 
   return reply;
 }
+
+
 
 /*!
  *  @brief  I2C low level interfacing

--- a/src/Adafruit_SGP40.h
+++ b/src/Adafruit_SGP40.h
@@ -33,10 +33,10 @@ extern "C" {
 #define SGP40_I2CADDR_DEFAULT 0x59 ///< SGP40 has only one I2C address
 
 // commands and constants
-#define SGP40_FEATURESET 0x0020 ///< The required set for this library
+#define SGP40_FEATURESET 0x0020    ///< The required set for this library
 #define SGP40_CRC8_POLYNOMIAL 0x31 ///< Seed for SGP40's CRC polynomial
-#define SGP40_CRC8_INIT 0xFF ///< Init value for CRC
-#define SGP40_WORD_LEN 2 ///< 2 bytes per word
+#define SGP40_CRC8_INIT 0xFF       ///< Init value for CRC
+#define SGP40_WORD_LEN 2           ///< 2 bytes per word
 
 /*!
  *  @brief  Class that stores state and functions for interacting with

--- a/src/Adafruit_SGP40.h
+++ b/src/Adafruit_SGP40.h
@@ -52,6 +52,7 @@ public:
   bool heaterOff();
   uint16_t measureRaw(float temperature = 25, float humidity = 50);
   int32_t measureVocIndex(float temperature = 25, float humidity = 50);
+  int32_t calculateVocIndex(uint16_t sraw, float temperature = 25, float humidity = 50);
 
   /** The 48-bit serial number, this value is set when you call {@link begin()}
    * **/

--- a/src/Adafruit_SGP40.h
+++ b/src/Adafruit_SGP40.h
@@ -33,10 +33,10 @@ extern "C" {
 #define SGP40_I2CADDR_DEFAULT 0x59 ///< SGP40 has only one I2C address
 
 // commands and constants
-#define SGP40_FEATURESET 0x0020    ///< The required set for this library
+#define SGP40_FEATURESET 0x0020 ///< The required set for this library
 #define SGP40_CRC8_POLYNOMIAL 0x31 ///< Seed for SGP40's CRC polynomial
-#define SGP40_CRC8_INIT 0xFF       ///< Init value for CRC
-#define SGP40_WORD_LEN 2           ///< 2 bytes per word
+#define SGP40_CRC8_INIT 0xFF ///< Init value for CRC
+#define SGP40_WORD_LEN 2 ///< 2 bytes per word
 
 /*!
  *  @brief  Class that stores state and functions for interacting with
@@ -52,7 +52,8 @@ public:
   bool heaterOff();
   uint16_t measureRaw(float temperature = 25, float humidity = 50);
   int32_t measureVocIndex(float temperature = 25, float humidity = 50);
-  int32_t calculateVocIndex(uint16_t sraw, float temperature = 25, float humidity = 50);
+  int32_t calculateVocIndex(uint16_t sraw, float temperature = 25,
+                            float humidity = 50);
 
   /** The 48-bit serial number, this value is set when you call {@link begin()}
    * **/


### PR DESCRIPTION
The recommended measurement cycle time of sgp40 is 1s.
With 2 sensors it was not possible to reach cycle time on rp2040.
Im interested in raw value and voc index.

After analysis two changes were made:
- Waiting time for sgp40_measure_raw_signal reduced from 250ms to 100ms. Data sheet says 30ms max runtime. So still big safety buffer of 70 ms available
- The function measureVocIndex makes a raw measurement.  In my case (i called measureRaw and then measureVocIndex) this lead to triggering raw measurement again. Therefore i added function calculateVocIndex which only calculates voc and takes raw value as parameter.

With the code changes, cycle time of 2 measuremts (raw+voc) was reduced from >1000ms to ~200ms :-)
