### PR TITLE
Fix memory leak by deleting i2c_dev in the destructor.

### DIFF
--- a/src/Adafruit_SGP40.cpp
+++ b/src/Adafruit_SGP40.cpp
@@ -37,6 +37,15 @@
 Adafruit_SGP40::Adafruit_SGP40() {}
 
 /*!
+ *  @brief  Frees memory used by SGP40 class
+ */
+Adafruit_SGP40::~Adafruit_SGP40() {
+  if (i2c_dev) {
+    delete i2c_dev;
+  }
+}
+
+/*!
  *  @brief  Setups the hardware and detects a valid SGP40. Initializes I2C
  *          then reads the serialnumber and checks that we are talking to an
  * SGP40

--- a/src/Adafruit_SGP40.h
+++ b/src/Adafruit_SGP40.h
@@ -46,6 +46,7 @@ extern "C" {
 class Adafruit_SGP40 {
  public:
   Adafruit_SGP40();
+  ~Adafruit_SGP40();
   bool begin(TwoWire* theWire = &Wire);
   bool selfTest(void);
 


### PR DESCRIPTION
Add a destructor that releases the dynamically allocated i2c_dev object to avoid memory leaks.